### PR TITLE
Refactoring MomoApi instantiation and updating tests and documentation

### DIFF
--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -85,9 +85,9 @@ class Transaction
         return $this->status === "FAILED";
     }
 
-    public function getAmount(): float
+    public function getAmount(): ?string
     {
-        return floatval($this->amount);
+        return $this->amount;
     }
 
     /**

--- a/src/Products/CollectionApi.php
+++ b/src/Products/CollectionApi.php
@@ -59,7 +59,6 @@ class CollectionApi extends ApiProduct
             'json' => $data,
             'headers' => [
                 'Ocp-Apim-Subscription-Key' => $this->getSubscriptionKey(),
-                //'X-Callback-Url' => $this->config->getCallbackUri(),
                 'X-Reference-Id' => $xReferenceId,
                 'X-Target-Environment' => $this->environment,
                 'Authorization' => 'Bearer ' . $token->getAccessToken(),

--- a/tests/MomoApiTest.php
+++ b/tests/MomoApiTest.php
@@ -9,32 +9,27 @@ use Symfony\Component\HttpClient\MockHttpClient;
 
 class MomoApiTest extends TestCase
 {
-    public function testEnvironnmentIsSandboxByDefault()
-    {
-        $this->assertEquals(MomoApi::$environment, MomoApi::ENVIRONMENT_SANDBOX);
-    }
-
     public function testBaseUrlByEnvironnment()
     {
-        $baseUrl = MomoApi::getBaseUrl();
+        $baseUrl = MomoApi::getBaseUrl(MomoApi::ENVIRONMENT_SANDBOX);
         $this->assertEquals(MomoApi::SANDBOX_URL, $baseUrl);
 
-        MomoApi::setEnvironment(MomoApi::ENVIRONMENT_MTN_CONGO);
-        $this->assertNotEquals(MomoApi::SANDBOX_URL, MomoApi::getBaseUrl());
+
+        $baseUrl = MomoApi::getBaseUrl(MomoApi::ENVIRONMENT_MTN_CONGO);
+        $this->assertEquals(MomoApi::PRODUCTION_URL, $baseUrl);
     }
 
     public function testFailGetCollectionWithoutConfig()
     {
         $this->expectException(InvalidArgumentException::class);
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->collection();
     }
 
     public function testFailUseSandboxInProduction()
     {
         $this->expectException(InvalidArgumentException::class);
-        MomoApi::setEnvironment(MomoApi::ENVIRONMENT_MTN_CONGO);
-        $momo = MomoApi::create('test');
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_MTN_CONGO);
         $momo->sandbox('subscriptionLey');
     }
 

--- a/tests/Products/CollectionApiTest.php
+++ b/tests/Products/CollectionApiTest.php
@@ -25,7 +25,7 @@ class CollectionApiTest extends TestCase
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->setupCollection(Config::collection($subscriptionKey, "apiUser", "apiKey", "aCalllback"));
         $momo->collection()->getAccessToken();
     }
@@ -41,14 +41,14 @@ class CollectionApiTest extends TestCase
         $expectedRequests = [
             function ($method, $url, $options) use ($sampleToken): MockResponse {
                 $this->assertSame('POST', $method);
-                $this->assertSame(MomoApi::getBaseUrl() . '/collection/token/', $url);
+                $this->assertSame($this->baseUrl() . '/collection/token/', $url);
                 $this->assertArrayHasKey('authorization', $options['normalized_headers']);
                 return new MockResponse(json_encode($sampleToken), ['http_code' => 200]);
             },
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->setupCollection(Config::collection('testSubKey', "apiUser", "apiKey", "aCalllback"));
         $token = $momo->collection()->getAccessToken();
 
@@ -60,7 +60,7 @@ class CollectionApiTest extends TestCase
         $expectedRequests = [
             function ($method, $url, $options): MockResponse {
                 $this->assertSame('POST', $method);
-                $this->assertSame(MomoApi::getBaseUrl() . '/collection/token/', $url);
+                $this->assertSame($this->baseUrl() . '/collection/token/', $url);
                 $this->assertArrayHasKey('authorization', $options['normalized_headers']);
                 return new MockResponse('{}', ['http_code' => 401]);
             },
@@ -68,7 +68,7 @@ class CollectionApiTest extends TestCase
 
         $this->expectException(MomoException::class);
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->setupCollection(Config::collection('testSubKey', "apiUser", "apiKey", "aCalllback"));
         $momo->collection()->getAccessToken();
     }
@@ -79,14 +79,14 @@ class CollectionApiTest extends TestCase
             $this->provideTokenResponse(),
             function ($method, $url, $options): MockResponse {
                 $this->assertSame('POST', $method);
-                $this->assertSame(MomoApi::getBaseUrl() . '/collection/v1_0/requesttopay', $url);
+                $this->assertSame($this->baseUrl() . '/collection/v1_0/requesttopay', $url);
                 $this->assertArrayHasKey('authorization', $options['normalized_headers']);
                 return new MockResponse('{}', ['http_code' => 202]);
             },
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->setupCollection(Config::collection('testSubKey', "apiUser", "apiKey", "aCalllback"));
 
         $request = new PaymentRequest(1000, 'EUR', 'ORDER-10', '46733123454', '', '');
@@ -99,7 +99,7 @@ class CollectionApiTest extends TestCase
     private function provideTokenResponse(): \Closure
     {
         return function ($method, $url): MockResponse {
-            $this->assertSame(MomoApi::getBaseUrl() . '/collection/token/', $url);
+            $this->assertSame($this->baseUrl() . '/collection/token/', $url);
             return new MockResponse(json_encode([
                 'access_token' => 'testToken',
                 'expires_in' => 3600,
@@ -118,7 +118,7 @@ class CollectionApiTest extends TestCase
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->setupCollection(Config::collection('testSubKey', "apiUser", "apiKey", "aCalllback"));
 
         $request = new PaymentRequest(1000, 'EUR', 'ORDER-10', '46733123454', '', '');
@@ -148,13 +148,13 @@ class CollectionApiTest extends TestCase
             $this->provideTokenResponse(),
             function ($method, $url) use ($paymentId, $data): MockResponse {
                 $this->assertSame('GET', $method);
-                $this->assertSame(MomoApi::getBaseUrl() . "/collection/v1_0/requesttopay/$paymentId", $url);
+                $this->assertSame($this->baseUrl() . "/collection/v1_0/requesttopay/$paymentId", $url);
                 return new MockResponse(json_encode($data), ['http_code' => 200]);
             },
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->setupCollection(Config::collection('testSubKey', "apiUser", "apiKey", "aCalllback"));
         $transaction = $momo->collection()->checkRequestStatus($paymentId);
 

--- a/tests/Products/SandboxApiTest.php
+++ b/tests/Products/SandboxApiTest.php
@@ -26,7 +26,7 @@ class SandboxApiTest extends TestCase
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->sandbox($subscriptionKey)->createApiKey('toto');
     }
 
@@ -38,7 +38,7 @@ class SandboxApiTest extends TestCase
         $expectedRequests = [
             function ($method, $url, $options) use ($callbackHost, $uuid): MockResponse {
                 $this->assertSame('POST', $method);
-                $this->assertSame(MomoApi::getBaseUrl() . '/v1_0/apiuser', $url);
+                $this->assertSame($this->baseUrl() . '/v1_0/apiuser', $url);
 
                 $this->assertSame(json_encode(["providerCallbackHost" => $callbackHost]), $options['body']);
                 $this->assertContains("X-Reference-Id: $uuid", $options['headers']);
@@ -48,7 +48,7 @@ class SandboxApiTest extends TestCase
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $result = $momo->sandbox('testSubKey')->createApiUser($uuid, $callbackHost);
 
         $this->assertEquals($uuid, $result);
@@ -68,7 +68,7 @@ class SandboxApiTest extends TestCase
         $this->expectException(ConflictException::class);
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->sandbox('testSubKey')->createApiUser($uuid, $callbackHost);
     }
 
@@ -85,7 +85,7 @@ class SandboxApiTest extends TestCase
         $this->expectException(BadRequestExeption::class);
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->sandbox('testSubKey')->createApiUser('badUUID', $callbackHost);
     }
 
@@ -100,14 +100,14 @@ class SandboxApiTest extends TestCase
         $expectedRequests = [
             function ($method, $url) use ($user, $uuid): MockResponse {
                 $this->assertSame('GET', $method);
-                $this->assertSame(MomoApi::getBaseUrl() . '/v1_0/apiuser/' . $uuid, $url);
+                $this->assertSame($this->baseUrl() . '/v1_0/apiuser/' . $uuid, $url);
 
                 return new MockResponse(json_encode($user), ['http_code' => 200]);
             },
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $result = $momo->sandbox('testSubKey')->getApiUser($uuid);
 
         $this->assertEquals($user, $result);
@@ -130,7 +130,7 @@ class SandboxApiTest extends TestCase
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->sandbox('testSubKey')->getApiUser($uuid);
     }
 
@@ -141,13 +141,13 @@ class SandboxApiTest extends TestCase
         $expectedRequests = [
             function ($method, $url) use ($apiUser): MockResponse {
                 $this->assertSame('POST', $method);
-                $this->assertSame(MomoApi::getBaseUrl() . "/v1_0/apiuser/$apiUser/apikey", $url);
+                $this->assertSame($this->baseUrl() . "/v1_0/apiuser/$apiUser/apikey", $url);
                 return new MockResponse('{"apiKey": "aKey"}', ['http_code' => 201]);
             },
         ];
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $result = $momo->sandbox('testSubKey')->createApiKey($apiUser);
 
         $this->assertSame($result, 'aKey');
@@ -166,7 +166,7 @@ class SandboxApiTest extends TestCase
         $this->expectException(MomoException::class);
 
         MomoApi::useClient($this->provideClient($expectedRequests));
-        $momo = MomoApi::create();
+        $momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
         $momo->sandbox('testSubKey')->createApiKey($apiUser);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,26 +14,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    public function setUp(): void
+    protected function baseUrl($env = MomoApi::ENVIRONMENT_SANDBOX)
     {
-        parent::setUp();
-
-        MomoApi::setEnvironment(MomoApi::ENVIRONMENT_SANDBOX);
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $reflection = new ReflectionClass(MomoApi::class);
-        $instanceProperty = $reflection->getProperty('instance');
-        $instanceProperty->setAccessible(true);
-        $instanceProperty->setValue(null);
+        return MomoApi::getBaseUrl($env);
     }
 
     protected function provideClient(array $responses): HttpClientInterface
     {
-        return new MockHttpClient($responses, MomoApi::getBaseUrl());
+        return new MockHttpClient($responses, MomoApi::getBaseUrl(MomoApi::ENVIRONMENT_SANDBOX));
     }
 
     protected function assertValidGuidV4($guid)


### PR DESCRIPTION
This pull request introduces the following changes:

1. Move the `$environment` param to the `create` factory method of the `MomoApi` class.
2. Update unit tests to accommodate this change.
3. Update documentation to reflect the changes made.

Previously, to instantiate the Momo API, the following code was used :

```php
$momo = MomoApi::create($subscriptionKey);
$momo->setEnvironment(MomoApi::ENVIRONMENT_SANDBOX);
```

Now, the instantiation of the Momo API is done as follows:

```php
$momo = MomoApi::create(MomoApi::ENVIRONMENT_SANDBOX);
```

The `$subscriptionKey` parameter has been moved to the configuration of each product because the `collection` and `disbursement` use different subscription keys.

These changes simplify the instantiation of MomoApi and make the configuration clearer and more modular. Unit tests have been updated to reflect these changes, ensuring the code functions correctly. The documentation has also been updated to explain the new method of instantiating the Momo API.