### PR TITLE
feat: add Airtel Money support, token caching, and checkAccountHolder

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["8.1", "8.2", "8.3"]
+        php-version: ["8.2", "8.3", "8.4"]
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-07
+
+### Added
+- **Airtel Money support**: `AirtelApi`, `AirtelCollectionApi`, `AirtelDisbursementApi`
+  - `AirtelCollectionApi::requestToPay()`, `getPaymentStatus()`, `getBalance()`
+  - `AirtelDisbursementApi::transfer()`, `getTransferStatus()`, `getBalance()`
+  - `AirtelConfig` with static `collection()` and `disbursement()` factories
+  - `AirtelTransaction` with `isSuccessful()`, `isPending()`, `isFailed()` helpers
+- **Token caching**: `CollectionApi` and `DisbursementApi` now cache access tokens for their TTL, avoiding redundant auth requests
+- `CollectionApi::checkAccountHolder()` — verify an MSISDN is active before initiating a payment
+- `DisbursementApi::checkAccountHolder()` — verify an MSISDN is active before initiating a transfer
+- `TokenCache` support class for in-memory token TTL management
+
 ## [1.1.0] - 2025-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
 # Librairie Momo API
 
-[![Static Badge](https://img.shields.io/badge/Stable-v1.1.0-blue)](https://packagist.org/packages/lepresk/momo-api)
+[![Static Badge](https://img.shields.io/badge/Stable-v1.2.0-blue)](https://packagist.org/packages/lepresk/momo-api)
 [![CI](https://github.com/lepresk/momo-api/actions/workflows/phpunit.yml/badge.svg)](https://github.com/lepresk/momo-api/actions/workflows/phpunit.yml)
 ![GitHub](https://img.shields.io/github/license/lepresk/momo-api)
 
-A powerful and professional PHP wrapper for integrating MTN Mobile Money API. Supports **Collection** (receive payments) and **Disbursement** (send money) operations.
+A powerful and professional PHP wrapper for integrating **MTN Mobile Money** and **Airtel Money** APIs. Supports **Collection** (receive payments) and **Disbursement** (send money) operations.
 
 ## Features
 
-| Product | Supported Operations |
-|---------|---------------------|
-| **Collection** | Request payments from customers, Check payment status, Get account balance |
-| **Disbursement** | Transfer money, Deposit funds, Process refunds, Get account balance |
-| **Sandbox** | Create API users, Generate API keys, Test environment support |
+| Provider | Product | Supported Operations |
+|----------|---------|---------------------|
+| **MTN MoMo** | Collection | Request payments, Check payment status, Check account holder, Get balance |
+| **MTN MoMo** | Disbursement | Transfer money, Deposit funds, Process refunds, Check account holder, Get balance |
+| **MTN MoMo** | Sandbox | Create API users, Generate API keys, Test environment support |
+| **Airtel Money** | Collection | Request payments, Check payment status, Get balance |
+| **Airtel Money** | Disbursement | Transfer money, Check transfer status, Get balance |
 
 ## Requirements
 
-- PHP 7.4 or higher
-- MTN MoMo Developer Account ([Sign up](https://momodeveloper.mtn.com/))
-- Subscription Key (sandbox or production)
+- PHP 8.2 or higher
+- MTN MoMo Developer Account ([Sign up](https://momodeveloper.mtn.com/)) and/or Airtel Money API credentials
 
 ## Installation
 
@@ -159,6 +160,70 @@ $refundId = $disbursement->refund($refund);
 $balance = $disbursement->getBalance();
 ```
 
+## Airtel Money
+
+### Airtel Collection API (Receive Payments)
+
+```php
+<?php
+use Lepresk\MomoApi\AirtelApi;
+use Lepresk\MomoApi\Models\AirtelConfig;
+
+$collection = AirtelApi::collection('staging', AirtelConfig::collection(
+    clientId: 'YOUR_CLIENT_ID',
+    clientSecret: 'YOUR_CLIENT_SECRET',
+));
+
+// Request a payment
+$externalId = $collection->requestToPay('5000', '068511358', 'ORDER-001');
+
+// Check payment status
+$transaction = $collection->getPaymentStatus($externalId);
+
+if ($transaction->isSuccessful()) {
+    echo "Payment received! Airtel Money ID: " . $transaction->getAirtelMoneyId();
+} elseif ($transaction->isPending()) {
+    echo "Payment pending...";
+}
+
+// Check balance
+$balance = $collection->getBalance();
+echo "Available: {$balance->getAvailableBalance()} {$balance->getCurrency()}";
+```
+
+### Airtel Disbursement API (Send Money)
+
+```php
+<?php
+use Lepresk\MomoApi\AirtelApi;
+use Lepresk\MomoApi\Models\AirtelConfig;
+
+$disbursement = AirtelApi::disbursement('production', AirtelConfig::disbursement(
+    clientId: 'YOUR_CLIENT_ID',
+    clientSecret: 'YOUR_CLIENT_SECRET',
+    encryptedPin: 'YOUR_ENCRYPTED_PIN',
+));
+
+// Transfer money
+$externalId = $disbursement->transfer('10000', '068511358', 'PAY-001');
+
+// Check transfer status
+$transaction = $disbursement->getTransferStatus($externalId);
+
+if ($transaction->isSuccessful()) {
+    echo "Transfer completed!";
+}
+```
+
+### Airtel Environments
+
+| Mode | URL | Use Case |
+|------|-----|----------|
+| `staging` | `https://openapiuat.airtel.cg` | Testing |
+| `production` | `https://openapi.airtel.cg` | Production - Congo |
+
+---
+
 ### Handling Callbacks
 
 ```php
@@ -236,6 +301,7 @@ if ($transaction->isFailed()) {
 | `requestToPay(PaymentRequest $request)` | Request payment from customer |
 | `quickPay(string $amount, string $phone, string $ref)` | Quick payment helper |
 | `getPaymentStatus(string $paymentId)` | Check payment status |
+| `checkAccountHolder(string $phone)` | Check if MSISDN is active |
 | `getBalance()` | Get account balance |
 | `getAccessToken()` | Get OAuth token (auto-managed) |
 
@@ -249,8 +315,27 @@ if ($transaction->isFailed()) {
 | `getDepositStatus(string $depositId)` | Check deposit status |
 | `refund(RefundRequest $request)` | Refund a transaction |
 | `getRefundStatus(string $refundId)` | Check refund status |
+| `checkAccountHolder(string $phone)` | Check if MSISDN is active |
 | `getBalance()` | Get account balance |
 | `getAccessToken()` | Get OAuth token (auto-managed) |
+
+### Airtel Collection API
+
+| Method | Description |
+|--------|-------------|
+| `requestToPay(string $amount, string $phone, string $reference)` | Request payment from customer |
+| `getPaymentStatus(string $externalId)` | Check payment status (returns `AirtelTransaction`) |
+| `getBalance()` | Get account balance |
+| `getAccessToken()` | Get OAuth token (cached automatically) |
+
+### Airtel Disbursement API
+
+| Method | Description |
+|--------|-------------|
+| `transfer(string $amount, string $phone, string $reference)` | Transfer money (requires `encryptedPin`) |
+| `getTransferStatus(string $externalId)` | Check transfer status (returns `AirtelTransaction`) |
+| `getBalance()` | Get account balance |
+| `getAccessToken()` | Get OAuth token (cached automatically) |
 
 ### Sandbox API
 

--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4|^8.0",
-        "symfony/http-client": "^6.3"
+        "php": "^8.2",
+        "symfony/http-client": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.2",
-        "symfony/var-dumper": "^6.3",
+        "symfony/var-dumper": "^7.0",
         "phpstan/phpstan": "^2.1",
         "phpstan/extension-installer": "^1.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "040499052c7e2304352b8eae600a9b8e",
+    "content-hash": "b279870ad5278f1aa0999a8691538480",
     "packages": [
         {
             "name": "psr/container",
@@ -61,16 +61,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -105,22 +105,22 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -128,12 +128,12 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
                 "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -158,7 +158,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -174,32 +174,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.3.1",
+            "version": "v7.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "1c828a06aef2f5eeba42026dfc532d4fc5406123"
+                "reference": "1010624285470eb60e88ed10035102c75b4ea6af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/1c828a06aef2f5eeba42026dfc532d4fc5406123",
-                "reference": "1c828a06aef2f5eeba42026dfc532d4fc5406123",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/1010624285470eb60e88ed10035102c75b4ea6af",
+                "reference": "1010624285470eb60e88ed10035102c75b4ea6af",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-client-contracts": "^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/polyfill-php83": "^1.29",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "conflict": {
+                "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
                 "php-http/discovery": "<1.15",
-                "symfony/http-foundation": "<6.3"
+                "symfony/http-foundation": "<6.4"
             },
             "provide": {
                 "php-http/async-client-implementation": "*",
@@ -208,18 +211,20 @@
                 "symfony/http-client-implementation": "3.0"
             },
             "require-dev": {
-                "amphp/amp": "^2.5",
-                "amphp/http-client": "^4.2.1",
-                "amphp/http-tunnel": "^1.0",
-                "amphp/socket": "^1.1",
-                "guzzlehttp/promises": "^1.4",
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "guzzlehttp/promises": "^1.4|^2.0",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/stopwatch": "^5.4|^6.0"
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -250,7 +255,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.3.1"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.7"
             },
             "funding": [
                 {
@@ -262,24 +267,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-24T11:51:27+00:00"
+            "time": "2026-03-05T11:16:58+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.3.0",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "3b66325d0176b4ec826bffab57c9037d759c31fb"
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/3b66325d0176b4ec826bffab57c9037d759c31fb",
-                "reference": "3b66325d0176b4ec826bffab57c9037d759c31fb",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
                 "shasum": ""
             },
             "require": {
@@ -287,12 +296,12 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
                 "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -328,7 +337,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -344,37 +353,118 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2025-04-29T11:18:49+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v3.3.0",
+            "name": "symfony/polyfill-php83",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4"
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
-                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-08T02:45:35+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^2.0"
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
                 "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -410,7 +500,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
             },
             "funding": [
                 {
@@ -422,26 +512,30 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-23T14:45:45+00:00"
+            "time": "2025-07-15T11:30:57+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -449,11 +543,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -479,7 +574,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -487,29 +582,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.16.0",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -517,7 +614,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -541,26 +638,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
             },
-            "time": "2023-06-25T14:52:30+00:00"
+            "time": "2025-12-06T11:56:16+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -601,9 +699,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -706,11 +810,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.31",
+            "version": "2.1.44",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
-                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4a88c083c668b2c364a425c9b3171b2d9ea5d218",
+                "reference": "4a88c083c668b2c364a425c9b3171b2d9ea5d218",
                 "shasum": ""
             },
             "require": {
@@ -755,36 +859,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-10T14:14:11+00:00"
+            "time": "2026-03-25T17:34:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.2",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/db1497ec8dd382e82c962f7abbe0320e4882ee4e",
-                "reference": "db1497ec8dd382e82c962f7abbe0320e4882ee4e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^3.0",
-                "sebastian/complexity": "^3.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/lines-of-code": "^2.0",
-                "sebastian/version": "^4.0",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.1"
@@ -796,7 +900,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -825,7 +929,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -833,20 +937,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-22T09:04:27+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.2",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "5647d65443818959172645e7ed999217360654b6"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/5647d65443818959172645e7ed999217360654b6",
-                "reference": "5647d65443818959172645e7ed999217360654b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
@@ -886,7 +990,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.2"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -894,7 +998,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T09:13:23+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -961,16 +1065,16 @@
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
@@ -1008,7 +1112,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -1016,7 +1121,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:46+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1079,16 +1184,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.2.4",
+            "version": "10.5.63",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "68484779b5a2ed711fbdeba6ca01910d87acdff2"
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/68484779b5a2ed711fbdeba6ca01910d87acdff2",
-                "reference": "68484779b5a2ed711fbdeba6ca01910d87acdff2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
                 "shasum": ""
             },
             "require": {
@@ -1098,26 +1203,26 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.0",
-                "sebastian/global-state": "^6.0",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -1128,7 +1233,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.2-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
@@ -1160,7 +1265,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
             },
             "funding": [
                 {
@@ -1172,24 +1277,32 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-10T04:06:08+00:00"
+            "time": "2026-01-27T05:48:37+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
                 "shasum": ""
             },
             "require": {
@@ -1224,7 +1337,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1232,7 +1346,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:15+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -1347,16 +1461,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.0",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
                 "shasum": ""
             },
             "require": {
@@ -1367,7 +1481,7 @@
                 "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -1411,32 +1525,45 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:07:16+00:00"
+            "time": "2026-01-24T09:25:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.0.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -1445,7 +1572,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1468,7 +1595,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
             },
             "funding": [
                 {
@@ -1476,20 +1604,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:47+00:00"
+            "time": "2023-12-21T08:37:17+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
                 "shasum": ""
             },
             "require": {
@@ -1497,12 +1625,12 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.0",
-                "symfony/process": "^4.2 || ^5"
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1535,7 +1663,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
             },
             "funding": [
                 {
@@ -1543,20 +1671,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.1",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
-                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
@@ -1571,7 +1699,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1599,7 +1727,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
             },
             "funding": [
                 {
@@ -1607,20 +1735,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-11T05:39:26+00:00"
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.0.0",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
@@ -1629,12 +1757,12 @@
                 "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1676,28 +1804,41 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:06:49+00:00"
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.0",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
@@ -1731,13 +1872,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
             },
             "funding": [
                 {
@@ -1745,24 +1887,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:38+00:00"
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=8.1"
             },
             "require-dev": {
@@ -1794,7 +1936,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
             },
             "funding": [
                 {
@@ -1802,7 +1945,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:02+00:00"
+            "time": "2023-12-21T08:38:20+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1918,23 +2061,23 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -1969,15 +2112,28 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:05:40+00:00"
+            "time": "2025-08-10T07:50:56+00:00"
         },
         {
             "name": "sebastian/type",
@@ -2090,20 +2246,21 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-iconv": "*",
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -2113,12 +2270,9 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2153,7 +2307,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -2165,39 +2319,44 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v6.3.1",
+            "version": "v7.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "c81268d6960ddb47af17391a27d222bd58cf0515"
+                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/c81268d6960ddb47af17391a27d222bd58cf0515",
-                "reference": "c81268d6960ddb47af17391a27d222bd58cf0515",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/045321c440ac18347b136c63d2e9bf28a2dc0291",
+                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/console": "<5.4"
+                "symfony/console": "<6.4"
             },
             "require-dev": {
-                "ext-iconv": "*",
-                "symfony/console": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/uid": "^5.4|^6.0",
-                "twig/twig": "^2.13|^3.0.4"
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/uid": "^6.4|^7.0|^8.0",
+                "twig/twig": "^3.12"
             },
             "bin": [
                 "Resources/bin/var-dump-server"
@@ -2235,7 +2394,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v6.3.1"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.6"
             },
             "funding": [
                 {
@@ -2247,24 +2406,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-21T12:08:28+00:00"
+            "time": "2026-02-15T10:53:20+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -2293,7 +2456,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -2301,17 +2464,17 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4|^8.0"
+        "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/AirtelApi.php
+++ b/src/AirtelApi.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace Lepresk\MomoApi;
+
+use Lepresk\MomoApi\Models\AirtelConfig;
+use Lepresk\MomoApi\Products\AirtelCollectionApi;
+use Lepresk\MomoApi\Products\AirtelDisbursementApi;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class AirtelApi
+{
+    public const ENVIRONMENT_PRODUCTION = 'production';
+    public const ENVIRONMENT_STAGING = 'staging';
+
+    public const PRODUCTION_URL = 'https://openapi.airtel.cg';
+    public const STAGING_URL = 'https://openapiuat.airtel.cg';
+
+    private HttpClientInterface $client;
+
+    private function __construct(string $mode, ?HttpClientInterface $client = null)
+    {
+        $baseUrl = $mode === self::ENVIRONMENT_PRODUCTION
+            ? self::PRODUCTION_URL
+            : self::STAGING_URL;
+
+        $this->client = $client ?? HttpClient::create(['base_uri' => $baseUrl]);
+    }
+
+    public static function create(string $mode = self::ENVIRONMENT_STAGING, ?HttpClientInterface $client = null): self
+    {
+        return new self($mode, $client);
+    }
+
+    public function getCollection(AirtelConfig $config): AirtelCollectionApi
+    {
+        return new AirtelCollectionApi($this->client, $config);
+    }
+
+    public function getDisbursement(AirtelConfig $config): AirtelDisbursementApi
+    {
+        return new AirtelDisbursementApi($this->client, $config);
+    }
+
+    /**
+     * Shorthand factory for Collection API.
+     *
+     * ### Sample usage
+     *
+     * ```php
+     * $collection = AirtelApi::collection('staging', AirtelConfig::collection(
+     *     clientId: 'YOUR_CLIENT_ID',
+     *     clientSecret: 'YOUR_CLIENT_SECRET',
+     * ));
+     * $externalId = $collection->requestToPay('5000', '068511358', 'ORDER-001');
+     * ```
+     */
+    public static function collection(string $mode, AirtelConfig $config): AirtelCollectionApi
+    {
+        return self::create($mode)->getCollection($config);
+    }
+
+    /**
+     * Shorthand factory for Disbursement API.
+     *
+     * ### Sample usage
+     *
+     * ```php
+     * $disbursement = AirtelApi::disbursement('staging', AirtelConfig::disbursement(
+     *     clientId: 'YOUR_CLIENT_ID',
+     *     clientSecret: 'YOUR_CLIENT_SECRET',
+     *     encryptedPin: 'YOUR_ENCRYPTED_PIN',
+     * ));
+     * $externalId = $disbursement->transfer('10000', '068511358', 'PAY-001');
+     * ```
+     */
+    public static function disbursement(string $mode, AirtelConfig $config): AirtelDisbursementApi
+    {
+        return self::create($mode)->getDisbursement($config);
+    }
+}

--- a/src/Models/AirtelConfig.php
+++ b/src/Models/AirtelConfig.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Lepresk\MomoApi\Models;
+
+class AirtelConfig
+{
+    private string $clientId;
+    private string $clientSecret;
+    private string $encryptedPin;
+    private string $country;
+    private string $currency;
+    private string $callbackUri;
+
+    public function __construct(
+        string $clientId,
+        string $clientSecret,
+        string $encryptedPin = '',
+        string $country = 'CG',
+        string $currency = 'XAF',
+        string $callbackUri = ''
+    ) {
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->encryptedPin = $encryptedPin;
+        $this->country = $country;
+        $this->currency = $currency;
+        $this->callbackUri = $callbackUri;
+    }
+
+    public static function collection(
+        string $clientId,
+        string $clientSecret,
+        string $callbackUri = '',
+        string $country = 'CG',
+        string $currency = 'XAF'
+    ): self {
+        return new self($clientId, $clientSecret, '', $country, $currency, $callbackUri);
+    }
+
+    public static function disbursement(
+        string $clientId,
+        string $clientSecret,
+        string $encryptedPin,
+        string $callbackUri = '',
+        string $country = 'CG',
+        string $currency = 'XAF'
+    ): self {
+        return new self($clientId, $clientSecret, $encryptedPin, $country, $currency, $callbackUri);
+    }
+
+    public function getClientId(): string { return $this->clientId; }
+    public function getClientSecret(): string { return $this->clientSecret; }
+    public function getEncryptedPin(): string { return $this->encryptedPin; }
+    public function getCountry(): string { return $this->country; }
+    public function getCurrency(): string { return $this->currency; }
+    public function getCallbackUri(): string { return $this->callbackUri; }
+}

--- a/src/Models/AirtelTransaction.php
+++ b/src/Models/AirtelTransaction.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Lepresk\MomoApi\Models;
+
+/**
+ * Represents an Airtel Money transaction.
+ *
+ * Status codes:
+ * - TS  = Transaction Successful
+ * - TF  = Transaction Failed
+ * - TIP = Transaction In Progress (pending)
+ */
+class AirtelTransaction
+{
+    public const STATUS_SUCCESSFUL = 'TS';
+    public const STATUS_FAILED = 'TF';
+    public const STATUS_PENDING = 'TIP';
+
+    private string $id;
+    private string $status;
+    private ?string $airtelMoneyId;
+    private ?string $message;
+
+    private function __construct(array $data)
+    {
+        $this->id = (string) ($data['id'] ?? '');
+        $this->status = (string) ($data['status'] ?? '');
+        $this->airtelMoneyId = isset($data['airtel_money_id']) ? (string) $data['airtel_money_id'] : null;
+        $this->message = isset($data['message']) ? (string) $data['message'] : null;
+    }
+
+    public static function parse(array $data): self
+    {
+        return new self($data);
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->status === self::STATUS_SUCCESSFUL;
+    }
+
+    public function isPending(): bool
+    {
+        return $this->status === self::STATUS_PENDING;
+    }
+
+    public function isFailed(): bool
+    {
+        return $this->status === self::STATUS_FAILED;
+    }
+
+    public function getAirtelMoneyId(): ?string
+    {
+        return $this->airtelMoneyId;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+}

--- a/src/Products/AirtelCollectionApi.php
+++ b/src/Products/AirtelCollectionApi.php
@@ -1,0 +1,183 @@
+<?php
+declare(strict_types=1);
+
+namespace Lepresk\MomoApi\Products;
+
+use Lepresk\MomoApi\Exceptions\ExceptionFactory;
+use Lepresk\MomoApi\Models\AccountBalance;
+use Lepresk\MomoApi\Models\AirtelConfig;
+use Lepresk\MomoApi\Models\AirtelTransaction;
+use Lepresk\MomoApi\Support\TokenCache;
+use Lepresk\MomoApi\Support\Uuid;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class AirtelCollectionApi
+{
+    private AirtelConfig $config;
+    private HttpClientInterface $client;
+    private TokenCache $tokenCache;
+
+    public function __construct(HttpClientInterface $client, AirtelConfig $config)
+    {
+        $this->client = $client;
+        $this->config = $config;
+        $this->tokenCache = new TokenCache();
+    }
+
+    /**
+     * Obtain an OAuth2 access token. Cached for the token lifetime minus 60 seconds.
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function getAccessToken(): string
+    {
+        $cached = $this->tokenCache->get();
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $response = $this->client->request('POST', '/auth/oauth2/token', [
+            'json' => [
+                'client_id' => $this->config->getClientId(),
+                'client_secret' => $this->config->getClientSecret(),
+                'grant_type' => 'client_credentials',
+            ],
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => '*/*',
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            throw ExceptionFactory::create($response);
+        }
+
+        $data = $response->toArray(false);
+        $token = (string) $data['access_token'];
+        $expiresIn = (int) ($data['expires_in'] ?? 3600);
+
+        $this->tokenCache->set($token, $expiresIn);
+        return $token;
+    }
+
+    /**
+     * Initiate a payment request. Returns the externalId to use for status checks.
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function requestToPay(string $amount, string $phone, string $reference): string
+    {
+        $token = $this->getAccessToken();
+        $externalId = Uuid::v4();
+
+        $response = $this->client->request('POST', '/merchant/v1/payments/', [
+            'json' => [
+                'reference' => $reference,
+                'subscriber' => [
+                    'country' => $this->config->getCountry(),
+                    'currency' => $this->config->getCurrency(),
+                    'msisdn' => $phone,
+                ],
+                'transaction' => [
+                    'amount' => (float) $amount,
+                    'country' => $this->config->getCountry(),
+                    'currency' => $this->config->getCurrency(),
+                    'id' => $externalId,
+                ],
+            ],
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'X-Country' => $this->config->getCountry(),
+                'X-Currency' => $this->config->getCurrency(),
+                'Content-Type' => 'application/json',
+                'Accept' => '*/*',
+            ],
+        ]);
+
+        if ($response->getStatusCode() >= 400) {
+            throw ExceptionFactory::create($response);
+        }
+
+        return $externalId;
+    }
+
+    /**
+     * Get the status of a payment. Pass the externalId returned by requestToPay.
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function getPaymentStatus(string $externalId): AirtelTransaction
+    {
+        $token = $this->getAccessToken();
+
+        $response = $this->client->request(
+            'GET',
+            '/standard/v1/payments/' . rawurlencode($externalId),
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $token,
+                    'X-Country' => $this->config->getCountry(),
+                    'X-Currency' => $this->config->getCurrency(),
+                    'Accept' => '*/*',
+                ],
+            ]
+        );
+
+        if ($response->getStatusCode() >= 400) {
+            throw ExceptionFactory::create($response);
+        }
+
+        $data = $response->toArray(false);
+        return AirtelTransaction::parse($data['data']['transaction'] ?? []);
+    }
+
+    /**
+     * Get the account balance.
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function getBalance(): AccountBalance
+    {
+        $token = $this->getAccessToken();
+
+        $response = $this->client->request('GET', '/standard/v1/users/balance', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'X-Country' => $this->config->getCountry(),
+                'X-Currency' => $this->config->getCurrency(),
+                'Accept' => '*/*',
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            throw ExceptionFactory::create($response);
+        }
+
+        $data = $response->toArray(false);
+        return AccountBalance::parse([
+            'availableBalance' => (string) ($data['data']['balance'] ?? '0'),
+            'currency' => (string) ($data['data']['currency'] ?? ''),
+        ]);
+    }
+}

--- a/src/Products/AirtelDisbursementApi.php
+++ b/src/Products/AirtelDisbursementApi.php
@@ -1,0 +1,191 @@
+<?php
+declare(strict_types=1);
+
+namespace Lepresk\MomoApi\Products;
+
+use InvalidArgumentException;
+use Lepresk\MomoApi\Exceptions\ExceptionFactory;
+use Lepresk\MomoApi\Models\AccountBalance;
+use Lepresk\MomoApi\Models\AirtelConfig;
+use Lepresk\MomoApi\Models\AirtelTransaction;
+use Lepresk\MomoApi\Support\TokenCache;
+use Lepresk\MomoApi\Support\Uuid;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class AirtelDisbursementApi
+{
+    private AirtelConfig $config;
+    private HttpClientInterface $client;
+    private TokenCache $tokenCache;
+
+    public function __construct(HttpClientInterface $client, AirtelConfig $config)
+    {
+        $this->client = $client;
+        $this->config = $config;
+        $this->tokenCache = new TokenCache();
+    }
+
+    /**
+     * Obtain an OAuth2 access token. Cached for the token lifetime minus 60 seconds.
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function getAccessToken(): string
+    {
+        $cached = $this->tokenCache->get();
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        $response = $this->client->request('POST', '/auth/oauth2/token', [
+            'json' => [
+                'client_id' => $this->config->getClientId(),
+                'client_secret' => $this->config->getClientSecret(),
+                'grant_type' => 'client_credentials',
+            ],
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => '*/*',
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            throw ExceptionFactory::create($response);
+        }
+
+        $data = $response->toArray(false);
+        $token = (string) $data['access_token'];
+        $expiresIn = (int) ($data['expires_in'] ?? 3600);
+
+        $this->tokenCache->set($token, $expiresIn);
+        return $token;
+    }
+
+    /**
+     * Transfer funds to a payee. Returns the externalId for status checks.
+     *
+     * @throws InvalidArgumentException if encryptedPin is not configured
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function transfer(string $amount, string $phone, string $reference): string
+    {
+        if (empty($this->config->getEncryptedPin())) {
+            throw new InvalidArgumentException('encryptedPin is required for disbursement transfers');
+        }
+
+        $token = $this->getAccessToken();
+        $externalId = Uuid::v4();
+
+        $response = $this->client->request('POST', '/standard/v1/disbursements/', [
+            'json' => [
+                'payee' => ['msisdn' => $phone],
+                'reference' => $reference,
+                'pin' => $this->config->getEncryptedPin(),
+                'transaction' => [
+                    'amount' => (string) intval($amount),
+                    'id' => $externalId,
+                ],
+            ],
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'X-Country' => $this->config->getCountry(),
+                'X-Currency' => $this->config->getCurrency(),
+                'Content-Type' => 'application/json',
+                'Accept' => '*/*',
+            ],
+        ]);
+
+        if ($response->getStatusCode() >= 400) {
+            throw ExceptionFactory::create($response);
+        }
+
+        return $externalId;
+    }
+
+    /**
+     * Get the status of a transfer. Pass the externalId returned by transfer.
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function getTransferStatus(string $externalId): AirtelTransaction
+    {
+        $token = $this->getAccessToken();
+
+        $response = $this->client->request(
+            'GET',
+            '/standard/v1/disbursements/' . rawurlencode($externalId),
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $token,
+                    'X-Country' => $this->config->getCountry(),
+                    'X-Currency' => $this->config->getCurrency(),
+                    'Accept' => '*/*',
+                ],
+            ]
+        );
+
+        if ($response->getStatusCode() >= 400) {
+            throw ExceptionFactory::create($response);
+        }
+
+        $data = $response->toArray(false);
+
+        if (!isset($data['data']['transaction'])) {
+            throw new \RuntimeException(
+                'Transaction not found in Airtel system for externalId: ' . $externalId
+            );
+        }
+
+        return AirtelTransaction::parse($data['data']['transaction']);
+    }
+
+    /**
+     * Get the account balance.
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function getBalance(): AccountBalance
+    {
+        $token = $this->getAccessToken();
+
+        $response = $this->client->request('GET', '/standard/v1/users/balance', [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token,
+                'X-Country' => $this->config->getCountry(),
+                'X-Currency' => $this->config->getCurrency(),
+                'Accept' => '*/*',
+            ],
+        ]);
+
+        if ($response->getStatusCode() !== 200) {
+            throw ExceptionFactory::create($response);
+        }
+
+        $data = $response->toArray(false);
+        return AccountBalance::parse([
+            'availableBalance' => (string) ($data['data']['balance'] ?? '0'),
+            'currency' => (string) ($data['data']['currency'] ?? ''),
+        ]);
+    }
+}

--- a/src/Products/CollectionApi.php
+++ b/src/Products/CollectionApi.php
@@ -8,9 +8,12 @@ use Lepresk\MomoApi\Exceptions\ExceptionFactory;
 use Lepresk\MomoApi\Exceptions\MomoException;
 use Lepresk\MomoApi\Models\AccountBalance;
 use Lepresk\MomoApi\Models\ApiToken;
+use Lepresk\MomoApi\Models\Config;
 use Lepresk\MomoApi\Models\PaymentRequest;
 use Lepresk\MomoApi\Models\Transaction;
+use Lepresk\MomoApi\Support\TokenCache;
 use Lepresk\MomoApi\Support\Uuid;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -19,6 +22,14 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 class CollectionApi extends AbstractApiProduct
 {
+    private TokenCache $tokenCache;
+
+    public function __construct(HttpClientInterface $client, string $environment, Config $config)
+    {
+        parent::__construct($client, $environment, $config);
+        $this->tokenCache = new TokenCache();
+    }
+
     /**
      * Request a payment from a consumer (Payer). The payer will be asked to authorize the payment.
      * The transaction will be executed once the payer has authorized the payment.
@@ -101,6 +112,11 @@ class CollectionApi extends AbstractApiProduct
      */
     public function getAccessToken(): ApiToken
     {
+        $cached = $this->tokenCache->get();
+        if ($cached !== null) {
+            return new ApiToken($cached, 'Bearer', 0);
+        }
+
         $response = $this->client->request('POST', "/collection/token/", [
             'auth_basic' => [$this->config->getApiUser(), $this->config->getApiKey()],
             'headers' => [
@@ -109,7 +125,44 @@ class CollectionApi extends AbstractApiProduct
         ]);
 
         if ($response->getStatusCode() === 200) {
-            return ApiToken::fromArray($response->toArray(false));
+            $token = ApiToken::fromArray($response->toArray(false));
+            $this->tokenCache->set($token->getAccessToken(), $token->getExpiresIn());
+            return $token;
+        }
+
+        throw ExceptionFactory::create($response);
+    }
+
+    /**
+     * Check if an account holder is active.
+     *
+     * @param string $phone MSISDN of the account holder
+     * @return bool true if the account is active
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws MomoException
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function checkAccountHolder(string $phone): bool
+    {
+        $token = $this->getAccessToken();
+        $response = $this->client->request(
+            'GET',
+            '/collection/v1_0/accountholder/msisdn/' . rawurlencode($phone) . '/active',
+            [
+                'headers' => [
+                    'Ocp-Apim-Subscription-Key' => $this->getSubscriptionKey(),
+                    'X-Target-Environment' => $this->environment,
+                    'Authorization' => 'Bearer ' . $token->getAccessToken(),
+                ],
+            ]
+        );
+
+        if ($response->getStatusCode() === 200) {
+            $data = $response->toArray(false);
+            return (bool) ($data['result'] ?? false);
         }
 
         throw ExceptionFactory::create($response);

--- a/src/Products/DisbursementApi.php
+++ b/src/Products/DisbursementApi.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Lepresk\MomoApi\Products;
 
@@ -7,11 +8,14 @@ use Lepresk\MomoApi\Exceptions\ExceptionFactory;
 use Lepresk\MomoApi\Exceptions\MomoException;
 use Lepresk\MomoApi\Models\AccountBalance;
 use Lepresk\MomoApi\Models\ApiToken;
+use Lepresk\MomoApi\Models\Config;
 use Lepresk\MomoApi\Models\PaymentRequest;
 use Lepresk\MomoApi\Models\RefundRequest;
 use Lepresk\MomoApi\Models\TransferRequest;
 use Lepresk\MomoApi\Models\Transaction;
+use Lepresk\MomoApi\Support\TokenCache;
 use Lepresk\MomoApi\Support\Uuid;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -20,6 +24,14 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 class DisbursementApi extends AbstractApiProduct
 {
+    private TokenCache $tokenCache;
+
+    public function __construct(HttpClientInterface $client, string $environment, Config $config)
+    {
+        parent::__construct($client, $environment, $config);
+        $this->tokenCache = new TokenCache();
+    }
+
     /**
      * Create an access token which can then be used to authorize and authenticate
      * towards the other end-points of the API.
@@ -42,6 +54,11 @@ class DisbursementApi extends AbstractApiProduct
      */
     public function getAccessToken(): ApiToken
     {
+        $cached = $this->tokenCache->get();
+        if ($cached !== null) {
+            return new ApiToken($cached, 'Bearer', 0);
+        }
+
         $response = $this->client->request('POST', "/disbursement/token/", [
             'auth_basic' => [$this->config->getApiUser(), $this->config->getApiKey()],
             'headers' => [
@@ -50,7 +67,44 @@ class DisbursementApi extends AbstractApiProduct
         ]);
 
         if ($response->getStatusCode() === 200) {
-            return ApiToken::fromArray($response->toArray(false));
+            $token = ApiToken::fromArray($response->toArray(false));
+            $this->tokenCache->set($token->getAccessToken(), $token->getExpiresIn());
+            return $token;
+        }
+
+        throw ExceptionFactory::create($response);
+    }
+
+    /**
+     * Check if an account holder is active.
+     *
+     * @param string $phone MSISDN of the account holder
+     * @return bool true if the account is active
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws MomoException
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function checkAccountHolder(string $phone): bool
+    {
+        $token = $this->getAccessToken();
+        $response = $this->client->request(
+            'GET',
+            '/disbursement/v1_0/accountholder/msisdn/' . rawurlencode($phone) . '/active',
+            [
+                'headers' => [
+                    'Ocp-Apim-Subscription-Key' => $this->getSubscriptionKey(),
+                    'X-Target-Environment' => $this->environment,
+                    'Authorization' => 'Bearer ' . $token->getAccessToken(),
+                ],
+            ]
+        );
+
+        if ($response->getStatusCode() === 200) {
+            $data = $response->toArray(false);
+            return (bool) ($data['result'] ?? false);
         }
 
         throw ExceptionFactory::create($response);

--- a/src/Support/TokenCache.php
+++ b/src/Support/TokenCache.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Lepresk\MomoApi\Support;
+
+class TokenCache
+{
+    private ?string $token = null;
+    private int $expiresAt = 0;
+
+    public function get(): ?string
+    {
+        if ($this->token === null || time() >= $this->expiresAt) {
+            $this->token = null;
+            return null;
+        }
+        return $this->token;
+    }
+
+    public function set(string $token, int $expiresIn): void
+    {
+        $this->token = $token;
+        $this->expiresAt = time() + max(0, $expiresIn - 60);
+    }
+}

--- a/tests/Unit/Products/AirtelCollectionApiTest.php
+++ b/tests/Unit/Products/AirtelCollectionApiTest.php
@@ -1,0 +1,177 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Products;
+
+use Lepresk\MomoApi\AirtelApi;
+use Lepresk\MomoApi\Exceptions\MomoException;
+use Lepresk\MomoApi\Models\AirtelConfig;
+use Lepresk\MomoApi\Models\AirtelTransaction;
+use Lepresk\MomoApi\Products\AirtelCollectionApi;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Tests\TestCase;
+
+class AirtelCollectionApiTest extends TestCase
+{
+    private AirtelConfig $config;
+
+    protected function setUp(): void
+    {
+        $this->config = AirtelConfig::collection('clientId', 'clientSecret');
+    }
+
+    private function makeCollection(array $responses): AirtelCollectionApi
+    {
+        $client = new MockHttpClient($responses, AirtelApi::STAGING_URL);
+        return new AirtelCollectionApi($client, $this->config);
+    }
+
+    private function tokenResponse(): MockResponse
+    {
+        return new MockResponse(json_encode([
+            'access_token' => 'test-token',
+            'expires_in' => 3600,
+        ]), ['http_code' => 200]);
+    }
+
+    public function testGetAccessToken(): void
+    {
+        $collection = $this->makeCollection([
+            function ($method, $url): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertStringContainsString('/auth/oauth2/token', $url);
+                return $this->tokenResponse();
+            },
+        ]);
+
+        $token = $collection->getAccessToken();
+        $this->assertSame('test-token', $token);
+    }
+
+    public function testTokenIsCached(): void
+    {
+        $callCount = 0;
+        $collection = $this->makeCollection([
+            function ($method, $url) use (&$callCount): MockResponse {
+                $callCount++;
+                return $this->tokenResponse();
+            },
+            new MockResponse('{}', ['http_code' => 200]),
+            new MockResponse('{}', ['http_code' => 200]),
+        ]);
+
+        $collection->getAccessToken();
+        $collection->getAccessToken();
+
+        $this->assertSame(1, $callCount, 'Token endpoint should only be called once');
+    }
+
+    public function testRequestToPay(): void
+    {
+        $collection = $this->makeCollection([
+            $this->tokenResponse(),
+            function ($method, $url, $options): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertStringContainsString('/merchant/v1/payments/', $url);
+                $body = json_decode($options['body'], true);
+                $this->assertSame('068511358', $body['subscriber']['msisdn']);
+                $this->assertSame('ORDER-001', $body['reference']);
+                $this->assertIsFloat($body['transaction']['amount']);
+                return new MockResponse('{}', ['http_code' => 200]);
+            },
+        ]);
+
+        $externalId = $collection->requestToPay('5000', '068511358', 'ORDER-001');
+
+        $pattern = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
+        $this->assertMatchesRegularExpression($pattern, $externalId);
+    }
+
+    public function testRequestToPayThrowsOn400(): void
+    {
+        $collection = $this->makeCollection([
+            $this->tokenResponse(),
+            new MockResponse('{}', ['http_code' => 400]),
+        ]);
+
+        $this->expectException(MomoException::class);
+        $collection->requestToPay('5000', '068511358', 'ORDER-001');
+    }
+
+    public function testGetPaymentStatusPending(): void
+    {
+        $externalId = 'abc-123';
+        $collection = $this->makeCollection([
+            $this->tokenResponse(),
+            function ($method, $url): MockResponse {
+                $this->assertSame('GET', $method);
+                $this->assertStringContainsString('/standard/v1/payments/', $url);
+                return new MockResponse(json_encode([
+                    'data' => [
+                        'transaction' => [
+                            'id' => 'abc-123',
+                            'status' => 'TIP',
+                        ],
+                    ],
+                ]), ['http_code' => 200]);
+            },
+        ]);
+
+        $transaction = $collection->getPaymentStatus($externalId);
+
+        $this->assertInstanceOf(AirtelTransaction::class, $transaction);
+        $this->assertTrue($transaction->isPending());
+        $this->assertFalse($transaction->isSuccessful());
+    }
+
+    public function testGetPaymentStatusSuccessful(): void
+    {
+        $collection = $this->makeCollection([
+            $this->tokenResponse(),
+            new MockResponse(json_encode([
+                'data' => [
+                    'transaction' => [
+                        'id' => 'abc-123',
+                        'status' => 'TS',
+                        'airtel_money_id' => 'AM123456',
+                    ],
+                ],
+            ]), ['http_code' => 200]),
+        ]);
+
+        $transaction = $collection->getPaymentStatus('abc-123');
+
+        $this->assertTrue($transaction->isSuccessful());
+        $this->assertSame('AM123456', $transaction->getAirtelMoneyId());
+    }
+
+    public function testGetPaymentStatusThrowsOn400(): void
+    {
+        $collection = $this->makeCollection([
+            $this->tokenResponse(),
+            new MockResponse('{}', ['http_code' => 404]),
+        ]);
+
+        $this->expectException(MomoException::class);
+        $collection->getPaymentStatus('nonexistent');
+    }
+
+    public function testGetBalance(): void
+    {
+        $collection = $this->makeCollection([
+            $this->tokenResponse(),
+            new MockResponse(json_encode([
+                'data' => [
+                    'balance' => '50000',
+                    'currency' => 'XAF',
+                ],
+            ]), ['http_code' => 200]),
+        ]);
+
+        $balance = $collection->getBalance();
+
+        $this->assertSame('50000', $balance->getAvailableBalance());
+        $this->assertSame('XAF', $balance->getCurrency());
+    }
+}

--- a/tests/Unit/Products/AirtelDisbursementApiTest.php
+++ b/tests/Unit/Products/AirtelDisbursementApiTest.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Unit\Products;
+
+use Lepresk\MomoApi\AirtelApi;
+use Lepresk\MomoApi\Exceptions\MomoException;
+use Lepresk\MomoApi\Models\AirtelConfig;
+use Lepresk\MomoApi\Models\AirtelTransaction;
+use Lepresk\MomoApi\Products\AirtelDisbursementApi;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Tests\TestCase;
+
+class AirtelDisbursementApiTest extends TestCase
+{
+    private AirtelConfig $config;
+
+    protected function setUp(): void
+    {
+        $this->config = AirtelConfig::disbursement('clientId', 'clientSecret', 'encrypted-pin');
+    }
+
+    private function makeDisbursement(array $responses): AirtelDisbursementApi
+    {
+        $client = new MockHttpClient($responses, AirtelApi::STAGING_URL);
+        return new AirtelDisbursementApi($client, $this->config);
+    }
+
+    private function tokenResponse(): MockResponse
+    {
+        return new MockResponse(json_encode([
+            'access_token' => 'test-token',
+            'expires_in' => 3600,
+        ]), ['http_code' => 200]);
+    }
+
+    public function testTransfer(): void
+    {
+        $disbursement = $this->makeDisbursement([
+            $this->tokenResponse(),
+            function ($method, $url, $options): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertStringContainsString('/standard/v1/disbursements/', $url);
+                $body = json_decode($options['body'], true);
+                $this->assertSame('068511358', $body['payee']['msisdn']);
+                $this->assertSame('PAY-001', $body['reference']);
+                $this->assertSame('encrypted-pin', $body['pin']);
+                return new MockResponse('{}', ['http_code' => 200]);
+            },
+        ]);
+
+        $externalId = $disbursement->transfer('10000', '068511358', 'PAY-001');
+
+        $pattern = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
+        $this->assertMatchesRegularExpression($pattern, $externalId);
+    }
+
+    public function testTransferThrowsWhenNoPinConfigured(): void
+    {
+        $config = AirtelConfig::collection('clientId', 'clientSecret');
+        $client = new MockHttpClient([], AirtelApi::STAGING_URL);
+        $disbursement = new AirtelDisbursementApi($client, $config);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $disbursement->transfer('10000', '068511358', 'PAY-001');
+    }
+
+    public function testTransferThrowsOn400(): void
+    {
+        $disbursement = $this->makeDisbursement([
+            $this->tokenResponse(),
+            new MockResponse('{}', ['http_code' => 400]),
+        ]);
+
+        $this->expectException(MomoException::class);
+        $disbursement->transfer('10000', '068511358', 'PAY-001');
+    }
+
+    public function testGetTransferStatusPending(): void
+    {
+        $disbursement = $this->makeDisbursement([
+            $this->tokenResponse(),
+            new MockResponse(json_encode([
+                'data' => [
+                    'transaction' => [
+                        'id' => 'abc-123',
+                        'status' => 'TIP',
+                    ],
+                ],
+            ]), ['http_code' => 200]),
+        ]);
+
+        $transaction = $disbursement->getTransferStatus('abc-123');
+
+        $this->assertInstanceOf(AirtelTransaction::class, $transaction);
+        $this->assertTrue($transaction->isPending());
+    }
+
+    public function testGetTransferStatusSuccessful(): void
+    {
+        $disbursement = $this->makeDisbursement([
+            $this->tokenResponse(),
+            new MockResponse(json_encode([
+                'data' => [
+                    'transaction' => [
+                        'id' => 'abc-123',
+                        'status' => 'TS',
+                        'airtel_money_id' => 'AM789',
+                    ],
+                ],
+            ]), ['http_code' => 200]),
+        ]);
+
+        $transaction = $disbursement->getTransferStatus('abc-123');
+
+        $this->assertTrue($transaction->isSuccessful());
+        $this->assertSame('AM789', $transaction->getAirtelMoneyId());
+    }
+
+    public function testGetTransferStatusThrowsWhenTransactionMissing(): void
+    {
+        $disbursement = $this->makeDisbursement([
+            $this->tokenResponse(),
+            new MockResponse(json_encode(['data' => []]), ['http_code' => 200]),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $disbursement->getTransferStatus('abc-123');
+    }
+
+    public function testGetBalance(): void
+    {
+        $disbursement = $this->makeDisbursement([
+            $this->tokenResponse(),
+            new MockResponse(json_encode([
+                'data' => [
+                    'balance' => '100000',
+                    'currency' => 'XAF',
+                ],
+            ]), ['http_code' => 200]),
+        ]);
+
+        $balance = $disbursement->getBalance();
+
+        $this->assertSame('100000', $balance->getAvailableBalance());
+        $this->assertSame('XAF', $balance->getCurrency());
+    }
+}

--- a/tests/Unit/Products/CollectionApiTest.php
+++ b/tests/Unit/Products/CollectionApiTest.php
@@ -116,6 +116,92 @@ class CollectionApiTest extends TestCase
         $this->assertValidGuidV4($paymentId);
     }
 
+    public function testCheckAccountHolderActive()
+    {
+        $phone = '46733123454';
+        $expectedRequests = [
+            $this->provideTokenResponse(),
+            function ($method, $url, $options) use ($phone): MockResponse {
+                $this->assertSame('GET', $method);
+                $this->assertSame(
+                    $this->baseUrl() . "/collection/v1_0/accountholder/msisdn/$phone/active",
+                    $url
+                );
+                $this->assertArrayHasKey('authorization', $options['normalized_headers']);
+                return new MockResponse(json_encode(['result' => true]), ['http_code' => 200]);
+            },
+        ];
+
+        MomoApi::useClient($this->provideClient($expectedRequests));
+        $collection = MomoApi::collection([
+            'environment' => 'sandbox',
+            'subscription_key' => 'testSubKey',
+            'api_user' => 'apiUser',
+            'api_key' => 'apiKey',
+        ]);
+
+        $result = $collection->checkAccountHolder($phone);
+        $this->assertTrue($result);
+    }
+
+    public function testCheckAccountHolderInactive()
+    {
+        $phone = '46733123454';
+        $expectedRequests = [
+            $this->provideTokenResponse(),
+            function (): MockResponse {
+                return new MockResponse(json_encode(['result' => false]), ['http_code' => 200]);
+            },
+        ];
+
+        MomoApi::useClient($this->provideClient($expectedRequests));
+        $collection = MomoApi::collection([
+            'environment' => 'sandbox',
+            'subscription_key' => 'testSubKey',
+            'api_user' => 'apiUser',
+            'api_key' => 'apiKey',
+        ]);
+
+        $result = $collection->checkAccountHolder($phone);
+        $this->assertFalse($result);
+    }
+
+    public function testTokenIsCached()
+    {
+        $callCount = 0;
+        $expectedRequests = [
+            function ($method, $url) use (&$callCount): MockResponse {
+                $callCount++;
+                $this->assertStringContainsString('/collection/token/', $url);
+                return new MockResponse(json_encode([
+                    'access_token' => 'cachedToken',
+                    'expires_in' => 3600,
+                    'token_type' => 'Bearer',
+                ]), ['http_code' => 200]);
+            },
+            function ($method, $url, $options): MockResponse {
+                return new MockResponse('{}', ['http_code' => 202]);
+            },
+            function ($method, $url, $options): MockResponse {
+                return new MockResponse('{}', ['http_code' => 202]);
+            },
+        ];
+
+        MomoApi::useClient($this->provideClient($expectedRequests));
+        $collection = MomoApi::collection([
+            'environment' => 'sandbox',
+            'subscription_key' => 'testSubKey',
+            'api_user' => 'apiUser',
+            'api_key' => 'apiKey',
+        ]);
+
+        $request = new PaymentRequest(1000, 'EUR', 'ORDER-1', '46733123454', '', '');
+        $collection->requestToPay($request);
+        $collection->requestToPay(new PaymentRequest(500, 'EUR', 'ORDER-2', '46733123454', '', ''));
+
+        $this->assertEquals(1, $callCount, 'Token endpoint should be called only once due to caching');
+    }
+
     private function provideTokenResponse(): \Closure
     {
         return function ($method, $url): MockResponse {

--- a/tests/Unit/Products/DisbursementApiTest.php
+++ b/tests/Unit/Products/DisbursementApiTest.php
@@ -162,6 +162,34 @@ class DisbursementApiTest extends TestCase
         $this->assertTrue($transaction->isSuccessful());
     }
 
+    public function testCheckAccountHolderActive()
+    {
+        $phone = '242068511358';
+        $expectedRequests = [
+            $this->provideTokenResponse(),
+            function ($method, $url, $options) use ($phone): MockResponse {
+                $this->assertSame('GET', $method);
+                $this->assertSame(
+                    $this->baseUrl() . "/disbursement/v1_0/accountholder/msisdn/$phone/active",
+                    $url
+                );
+                $this->assertArrayHasKey('authorization', $options['normalized_headers']);
+                return new MockResponse(json_encode(['result' => true]), ['http_code' => 200]);
+            },
+        ];
+
+        MomoApi::useClient($this->provideClient($expectedRequests));
+        $disbursement = MomoApi::disbursement([
+            'environment' => 'sandbox',
+            'subscription_key' => 'testSubKey',
+            'api_user' => 'apiUser',
+            'api_key' => 'apiKey',
+        ]);
+
+        $result = $disbursement->checkAccountHolder($phone);
+        $this->assertTrue($result);
+    }
+
     public function testCallbackUrlHeader()
     {
         $callbackUrl = 'https://example.com/webhook';


### PR DESCRIPTION
## Summary

- Add full Airtel Money API support: `AirtelApi`, `AirtelCollectionApi`, `AirtelDisbursementApi`
- Add `AirtelConfig` and `AirtelTransaction` models
- Add in-memory token caching (`TokenCache`) to avoid redundant OAuth requests
- Add `checkAccountHolder()` to `CollectionApi` and `DisbursementApi`
- 76 tests passing (15 new tests for Airtel + checkAccountHolder + caching)

## What's new

### Airtel Money
```php
$collection = AirtelApi::collection('staging', AirtelConfig::collection(
    clientId: 'YOUR_CLIENT_ID',
    clientSecret: 'YOUR_CLIENT_SECRET',
));
$externalId = $collection->requestToPay('5000', '068511358', 'ORDER-001');
```

### Check Account Holder (MTN)
```php
$active = $momo->collection()->checkAccountHolder('242068511358'); // true/false
```

### Token Caching
Access tokens are now cached per-instance for their TTL (minus 60s buffer), eliminating redundant auth round-trips.