### PR TITLE
fix: apply base_uri via withOptions() when custom client is injected

### DIFF
--- a/src/MomoApi.php
+++ b/src/MomoApi.php
@@ -68,6 +68,8 @@ class MomoApi
             self::$client = HttpClient::create([
                 'base_uri' => self::getBaseUrl($environment),
             ]);
+        } else {
+            self::$client = self::$client->withOptions(['base_uri' => self::getBaseUrl($environment)]);
         }
         return new self($environment);
     }
@@ -90,6 +92,8 @@ class MomoApi
             self::$client = HttpClient::create([
                 'base_uri' => self::getBaseUrl($environment),
             ]);
+        } else {
+            self::$client = self::$client->withOptions(['base_uri' => self::getBaseUrl($environment)]);
         }
 
         $configObject = Config::collection($subscriptionKey, $apiUser, $apiKey, $callbackUrl);
@@ -114,6 +118,8 @@ class MomoApi
             self::$client = HttpClient::create([
                 'base_uri' => self::getBaseUrl($environment),
             ]);
+        } else {
+            self::$client = self::$client->withOptions(['base_uri' => self::getBaseUrl($environment)]);
         }
 
         $configObject = Config::disbursement($subscriptionKey, $apiUser, $apiKey, $callbackUrl);


### PR DESCRIPTION
## Summary

- Fixes #10
- When `useClient()` was called before `collection()`, `disbursement()`, or `create()`, the `base_uri` setup block was skipped entirely (guarded by `self::$client === null`), causing Symfony to throw `Invalid URL: scheme is missing` on relative paths.
- Added an `else` branch in all three methods that calls `withOptions(['base_uri' => ...])` on the existing client.

## Test plan

- [x] All 76 existing tests pass (`composer test`)
- [ ] Manual reproduction from issue #10 no longer throws `Invalid URL: scheme is missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)