### PR TITLE
fix: correct getPayee() and silent env fallback

### DIFF
--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -14,6 +14,7 @@ class Transaction
     private ?string $amount;
     private string $currency;
     private array $payer = [];
+    private array $payee = [];
     private ?string $payerMessage;
     private ?string $payeeNote;
     private string $status;
@@ -31,13 +32,14 @@ class Transaction
      * @param string $status
      * @param ErrorReason|null $reason
      */
-    public function __construct(?string $financialTransactionId, ?string $externalId, ?string $amount, string $currency, array $payer, ?string $payerMessage, ?string $payeeNote, string $status, ?ErrorReason $reason)
+    public function __construct(?string $financialTransactionId, ?string $externalId, ?string $amount, string $currency, array $payer, array $payee, ?string $payerMessage, ?string $payeeNote, string $status, ?ErrorReason $reason)
     {
         $this->financialTransactionId = $financialTransactionId;
         $this->externalId = $externalId;
         $this->amount = $amount;
         $this->currency = $currency;
         $this->payer = $payer;
+        $this->payee = $payee;
         $this->payerMessage = $payerMessage;
         $this->payeeNote = $payeeNote;
         $this->status = $status;
@@ -63,7 +65,8 @@ class Transaction
             $array['externalId'],
             $array['amount'],
             $array['currency'],
-            $array['payer'] ?? $array['payee'] ?? [],
+            $array['payer'] ?? [],
+            $array['payee'] ?? [],
             $array['payerMessage'],
             $array['payeeNote'],
             $array['status'],
@@ -158,7 +161,7 @@ class Transaction
      */
     public function getPayee(): ?string
     {
-        return $this->getPayer();
+        return $this->payee['partyId'] ?? null;
     }
 
     /**

--- a/src/MomoApi.php
+++ b/src/MomoApi.php
@@ -128,8 +128,19 @@ class MomoApi
 
     public static function getBaseUrl($environment): string
     {
-        if ($environment === MomoApi::ENVIRONMENT_SANDBOX) {
+        if ($environment === self::ENVIRONMENT_SANDBOX) {
             return self::SANDBOX_URL;
+        }
+        $known = [
+            self::ENVIRONMENT_MTN_CONGO, self::ENVIRONMENT_MTN_UGANDA,
+            self::ENVIRONMENT_MTN_GHANA, self::ENVIRONMENT_IVORY_COAST,
+            self::ENVIRONMENT_ZAMBIA, self::ENVIRONMENT_CAMEROON,
+            self::ENVIRONMENT_BENIN, self::ENVIRONMENT_SWAZILAND,
+            self::ENVIRONMENT_GUINEACONAKRY, self::ENVIRONMENT_SOUTHAFRICA,
+            self::ENVIRONMENT_LIBERIA,
+        ];
+        if (!in_array($environment, $known, true)) {
+            throw new \InvalidArgumentException("Unknown environment: '$environment'");
         }
         return self::PRODUCTION_URL;
     }

--- a/src/MomoApi.php
+++ b/src/MomoApi.php
@@ -68,6 +68,8 @@ class MomoApi
             self::$client = HttpClient::create([
                 'base_uri' => self::getBaseUrl($environment),
             ]);
+        } else {
+            self::$client = self::$client->withOptions(['base_uri' => self::getBaseUrl($environment)]);
         }
         return new self($environment);
     }
@@ -90,6 +92,8 @@ class MomoApi
             self::$client = HttpClient::create([
                 'base_uri' => self::getBaseUrl($environment),
             ]);
+        } else {
+            self::$client = self::$client->withOptions(['base_uri' => self::getBaseUrl($environment)]);
         }
 
         $configObject = Config::collection($subscriptionKey, $apiUser, $apiKey, $callbackUrl);
@@ -114,6 +118,8 @@ class MomoApi
             self::$client = HttpClient::create([
                 'base_uri' => self::getBaseUrl($environment),
             ]);
+        } else {
+            self::$client = self::$client->withOptions(['base_uri' => self::getBaseUrl($environment)]);
         }
 
         $configObject = Config::disbursement($subscriptionKey, $apiUser, $apiKey, $callbackUrl);

--- a/src/Products/AirtelDisbursementApi.php
+++ b/src/Products/AirtelDisbursementApi.php
@@ -95,7 +95,7 @@ class AirtelDisbursementApi
                 'reference' => $reference,
                 'pin' => $this->config->getEncryptedPin(),
                 'transaction' => [
-                    'amount' => (string) $amount,
+                    'amount' => (string) intval($amount),
                     'id' => $externalId,
                 ],
             ],

--- a/src/Products/AirtelDisbursementApi.php
+++ b/src/Products/AirtelDisbursementApi.php
@@ -95,7 +95,7 @@ class AirtelDisbursementApi
                 'reference' => $reference,
                 'pin' => $this->config->getEncryptedPin(),
                 'transaction' => [
-                    'amount' => (string) intval($amount),
+                    'amount' => (string) $amount,
                     'id' => $externalId,
                 ],
             ],


### PR DESCRIPTION
## Summary

Two bugs fixed:

- **Fixes #12** — `Transaction::getPayee()` was calling `getPayer()` (copy-paste error). The model now stores `$payer` and `$payee` as separate fields; `parse()` maps them from the correct API keys.
- **Fixes #15** — `MomoApi::getBaseUrl()` fell back to `PRODUCTION_URL` for any unknown environment string. Now throws `InvalidArgumentException` for values not in the list of known constants.

## Test plan

- [x] All 76 existing tests pass (`composer test`)
- [ ] Verify `getPayee()` returns correct beneficiary on a disbursement transaction
- [ ] Verify passing `'Sandbox'` (wrong case) throws instead of routing to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)